### PR TITLE
Update name of Coverage module

### DIFF
--- a/django_jenkins/tasks/with_coverage.py
+++ b/django_jenkins/tasks/with_coverage.py
@@ -2,7 +2,7 @@
 # pylint: disable=W0201
 import os
 from optparse import make_option
-from coverage.control import coverage
+from coverage.control import Coverage
 from django.conf import settings
 from django.utils.importlib import import_module
 from django_jenkins.tasks import BaseTask, get_apps_under_test
@@ -66,7 +66,7 @@ class Task(BaseTask):
                         getattr(settings, 'COVERAGE_EXCLUDES_FOLDERS', []))
         #import ipdb; ipdb.set_trace()
 
-        self.coverage = coverage(branch=self.branch,
+        self.coverage = Coverage(branch=self.branch,
                                  source=self.test_apps,
                                  omit=self.exclude_locations,
                                  config_file=options.get('coverage_rcfile') or

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     ],
     install_requires=[
         'Django>=1.3',
-        'coverage>=3.4',
+        'coverage>=4.0',
         'pylint>=0.23',
     ],
     packages = ['django_jenkins', 'django_jenkins.management', 'django_jenkins.tasks', 'django_jenkins.management.commands'],


### PR DESCRIPTION
As of coverage v4.0, `coverage.control.coverage` has been renamed to `coverage.control.Coverage` (see the [Changelog](https://github.com/nedbat/coveragepy/blob/master/CHANGES.rst#version-40a1-----2014-09-27) ). Update references to `coverage` to maintain compatibility.